### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -80,15 +80,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Git Hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow configuration and Justfile to improve dependency management and streamline the `zizmor` checking process. Key changes include upgrading the `uv` setup action, adding support for `Just`, and modifying commands for consistency and clarity.

### Workflow updates:
* Updated `.github/workflows/code-checks.yml` to use `astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca` (v6.0.1) and added `extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` (v3) for setting up `Just`.
* Changed the `Run zizmor` step to use the `just zizmor-check-sarif` command for improved consistency and integration with `Just`.
* Updated the SARIF file upload action to `github/codeql-action/upload-sarif@v3.28.17`.

### Justfile updates:
* Modified the `zizmor-check` command to use `uvx` for running `zizmor` with the `pedantic` persona.
* Added a new `zizmor-check-sarif` command in `Justfile` to generate SARIF output for `zizmor` checks, aligning with the workflow changes.