### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small correction to the file pattern used for labeling documentation-related files. The change updates the spelling of the license file from "LICENSE" to "LICENCE" in the `.github/other-configurations/labeller.yml` configuration.