### PR TITLE
Add GitHub Workflow Permission Notes and Reorder Jobs

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,25 +19,25 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  common-code-checks:
-    name: Common Code Checks
-    permissions:
-      contents: read
-      actions: read
-      pull-requests: write
-      security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@4105a10d43925314414dc63b2b5c96137d2895fb # v2026.01.10.01
-    secrets:
-      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
-
   codeql-checks:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     strategy:
       matrix:
         language: [actions]
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@4105a10d43925314414dc63b2b5c96137d2895fb # v2026.01.10.01
     with:
       language: ${{ matrix.language }}
+
+  common-code-checks:
+    name: Common Code Checks
+    permissions:
+      contents: read
+      actions: read # Allow the workflow to read actions metadata
+      pull-requests: write # Allow the workflow to create and modify pull request comments
+      security-events: write # Allow the workflow to upload analysis results
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@4105a10d43925314414dc63b2b5c96137d2895fb # v2026.01.10.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -14,7 +14,7 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
-      pull-requests: write
+      pull-requests: write # For writing labels and comments on PRs
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@4105a10d43925314414dc63b2b5c96137d2895fb # v2026.01.10.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,7 +19,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # For writing labels to the repository
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@4105a10d43925314414dc63b2b5c96137d2895fb # v2026.01.10.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to improve clarity and maintainability by adding explanatory comments to permission settings. Additionally, there is a minor reordering of jobs in one workflow file.

Workflow improvements:

* Added comments to permission settings in `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml` to clarify the purpose of each permission, such as why `pull-requests: write` or `security-events: write` are required. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L22-R43) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL17-R17) [[3]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L22-R22)

Organizational changes:

* Reordered the `common-code-checks` and `codeql-checks` jobs in `.github/workflows/code-checks.yml` for improved structure, but without functional changes.